### PR TITLE
[TEMP REVIEW] Rebased diffColumnDefaultValueConstraintName onto current master

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
@@ -60,6 +60,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
 
     public static final ConfigurationDefinition<Boolean> PRESERVE_CLASSPATH_PREFIX_IN_NORMALIZED_PATHS;
     public static final ConfigurationDefinition<Boolean> ALLOW_INHERIT_LOGICAL_FILE_PATH;
+    public static final ConfigurationDefinition<Boolean> DIFF_COLUMN_DEFAULT_VALUE_CONSTRAINT_NAME;
 
     static {
         ConfigurationDefinition.Builder builder = new ConfigurationDefinition.Builder("liquibase");
@@ -278,6 +279,11 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
 
         ALLOW_INHERIT_LOGICAL_FILE_PATH = builder.define("allowInheritLogicalFilePath", Boolean.class)
                 .setDescription("If true, included changelogs without an explicit logicalFilePath will inherit their parent changelog's logicalFilePath, and explicit logicalFilePath attributes on include statements are honored (Liquibase 4.31.0+ behavior). If false, included changelogs use their physical file paths, ignoring both implicit inheritance and explicit logicalFilePath attributes on include statements. Only logicalFilePath set directly on the changelog itself is respected. Defaults to true for backward compatibility.")
+                .setDefaultValue(true)
+                .build();
+
+        DIFF_COLUMN_DEFAULT_VALUE_CONSTRAINT_NAME = builder.define("diffColumnDefaultValueConstraintName", Boolean.class)
+                .setDescription("Should Liquibase compare column default value constraint name in diff operation?")
                 .setDefaultValue(true)
                 .build();
     }

--- a/liquibase-standard/src/main/java/liquibase/diff/compare/core/ColumnComparator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/compare/core/ColumnComparator.java
@@ -85,6 +85,10 @@ public class ColumnComparator implements DatabaseObjectComparator {
             exclude.add("order");
         }
 
+        if (!GlobalConfiguration.DIFF_COLUMN_DEFAULT_VALUE_CONSTRAINT_NAME.getCurrentValue()) {
+            exclude.add("defaultValueConstraintName");
+        }
+
         ObjectDifferences differences = chain.findDifferences(databaseObject1, databaseObject2, accordingTo, compareControl, exclude);
 
         DataType type1 = ((Column) databaseObject1).getType();


### PR DESCRIPTION
Temp PR to review the rebased changes before updating the original PR branch (#1729).

## What changed vs the original PR
- Files are now under `liquibase-standard/` (renamed from `liquibase-core/`)
- Changes applied on top of current master (3021 commits ahead)
- Logic is identical to the original — only 2 files, +10 lines

## Changes
- `GlobalConfiguration.java`: added `DIFF_COLUMN_DEFAULT_VALUE_CONSTRAINT_NAME` field declaration and builder init
- `ColumnComparator.java`: added `defaultValueConstraintName` exclusion check after the existing `DIFF_COLUMN_ORDER` block

**After review approval, the original branch `add-global-configuraion-diffColumnDefaultValueConstraintName` will be reset to this and force-pushed.**